### PR TITLE
Enable passing eviction policy via command-line args

### DIFF
--- a/memcrs/src/memcache/builder.rs
+++ b/memcrs/src/memcache/builder.rs
@@ -11,9 +11,9 @@ pub struct MemcacheStoreConfig {
 }
 
 impl MemcacheStoreConfig {
-    pub fn new(memory_limit: u64) -> MemcacheStoreConfig {
+    pub fn new(memory_limit: u64, policy: EvictionPolicy) -> MemcacheStoreConfig {
         MemcacheStoreConfig {
-            policy: EvictionPolicy::None,
+            policy,
             memory_limit,
         }
     }

--- a/memcrs/src/memcache/cli/parser.rs
+++ b/memcrs/src/memcache/cli/parser.rs
@@ -1,6 +1,7 @@
 use byte_unit::{Byte};
 use clap::{command, Parser, ValueEnum};
 use std::{net::IpAddr, ops::RangeInclusive, fmt::Debug};
+use crate::memcache::eviction_policy::EvictionPolicy;
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
 pub enum RuntimeType {
@@ -69,6 +70,10 @@ pub struct MemcrsArgs {
     #[arg(short, long, value_name = "RUNTIME-TYPE", default_value_t = RuntimeType::CurrentThread, value_enum)]
     ///  runtime type to use
     pub runtime_type: RuntimeType,
+
+    #[arg(short, long, value_name = "EVICTION-POLICY", value_parser = parse_eviction_policy, default_value_t = EvictionPolicy::None, value_enum)]
+    /// eviction policy to use
+    pub eviction_policy: EvictionPolicy,
 }
 
 const PORT_RANGE: RangeInclusive<usize> = 1..=65535;
@@ -99,6 +104,14 @@ fn parse_memory_mb(s: &str) -> Result<u64, String> {
                 byte_error
             ))
         }
+    }
+}
+
+fn parse_eviction_policy(s: &str) -> Result<EvictionPolicy, String> {
+    match s {
+        "random" => Ok(EvictionPolicy::Random),
+        "none" => Ok(EvictionPolicy::None),
+        _ => Err(format!("Invalid eviction policy: {}", s)),
     }
 }
 

--- a/memcrs/src/memcache/eviction_policy.rs
+++ b/memcrs/src/memcache/eviction_policy.rs
@@ -1,4 +1,6 @@
-#[derive(Debug)]
+use clap::ValueEnum;
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum EvictionPolicy {
     None,
     Random,

--- a/memcrs/src/memcache_server/runtime_builder.rs
+++ b/memcrs/src/memcache_server/runtime_builder.rs
@@ -105,7 +105,7 @@ pub fn create_memcrs_server(
     config: MemcrsArgs,
     system_timer: std::sync::Arc<server::timer::SystemTimer>,
 ) -> tokio::runtime::Runtime {
-    let store_config = memcache::builder::MemcacheStoreConfig::new(config.memory_limit);
+    let store_config = memcache::builder::MemcacheStoreConfig::new(config.memory_limit, config.eviction_policy);
     let memcache_store =
         memcache::builder::MemcacheStoreBuilder::from_config(store_config, system_timer);
 


### PR DESCRIPTION
While experimenting with extending memc-rs by adding additional cache eviction policies, I noticed that there was no obvious way to change the eviction policy outside of making a change in `MemcacheStoreConfig::new(...)` (followed by recompile).

This PR adds the ability to specify an eviction policy at runtime by supplying the `eviction-policy` command-line argument.

PS. I'm still fairly new to Rust, so please point out if I'm breaking any conventions/missing something obvious. Thanks!